### PR TITLE
Fix UseCDF_CMF flag and remove very large climatological runoff values

### DIFF
--- a/map/src/src_param/Makefile
+++ b/map/src/src_param/Makefile
@@ -27,5 +27,5 @@ clean:
 
 .SUFFIXES : .F90
 .F90:
-	$(FC) $(FFLAGS) $(LFLAG) $(INC) $^ -o $@
+	$(FC) $(FFLAGS) $(LFLAG) $(CFLAGS) $(INC) $^ -o $@
 

--- a/map/src/src_param/calc_outclm.F90
+++ b/map/src/src_param/calc_outclm.F90
@@ -4,7 +4,7 @@
 ! using runoff climatology (daily mean over 20~30 years)
 ! -- 30day max discharge calculation is deactivated in CaMa-Flood v4. Please set lout30=.true.
 ! ================================================
-#ifdef UseCDF
+#ifdef UseCDF_CMF
 USE NETCDF
 #endif
       implicit none
@@ -32,7 +32,7 @@ USE NETCDF
       logical             ::  lout30                  !! set lout30=.true. if 30day max discharge should be calculated.
       parameter              (lout30=.false.)
 
-#ifdef UseCDF
+#ifdef UseCDF_CMF
       integer             ::  ncid, varid
 #endif
 
@@ -267,7 +267,7 @@ print *, trim(crofbin)
         close(14)
       endif
 
-#ifdef UseCDF
+#ifdef UseCDF_CMF
       if( type=='cdf')then
 print *, trim(crofcdf)
         CALL NCERROR ( NF90_OPEN(crofcdf,NF90_NOWRITE,NCID),'READING'//TRIM(crofcdf) )
@@ -316,6 +316,9 @@ print *, 'calc_outclm: calc annual average'
       do iy=1, ny
         do ix=1, nx
           if( nextx(ix,iy)==-9999 )then
+            rivout(ix,iy)=-9999
+          endif
+          if( nextx(ix,iy)>1.e10 )then
             rivout(ix,iy)=-9999
           endif
         end do
@@ -379,8 +382,8 @@ print *, 'calc_outclm: calc mday maximum: mday=', mday
 
 ! ============================================================
 
-#ifdef UseCDF
       CONTAINS
+#ifdef UseCDF_CMF
 
 !!==================================================
       SUBROUTINE NCERROR(STATUS,STRING)
@@ -401,7 +404,6 @@ print *, 'calc_outclm: calc mday maximum: mday=', mday
       END SUBROUTINE NCERROR
 #endif
 
-CONTAINS
 !+
 !+
 !+

--- a/map/src/src_param/calc_rivwth.F90
+++ b/map/src/src_param/calc_rivwth.F90
@@ -4,7 +4,7 @@
 ! using power-law function of annual mean discharge (outclm.bin)
 ! + distributed manning roughness is also generated (rivman.bin)
 ! ================================================
-#ifdef UseCDF
+#ifdef UseCDF_CMF
 USE NETCDF
 #endif
       implicit none
@@ -55,7 +55,7 @@ USE NETCDF
       parameter              (crivman='./rivman.bin')
       integer             ::  ios
 !
-#ifdef UseCDF
+#ifdef UseCDF_CMF
       character*256       ::  crivpar
       parameter              (crivpar='./rivpar.nc')
       integer             ::  ncid,varid,xid,yid
@@ -186,7 +186,7 @@ print *, 'calc_rivwth: width & depth calculation'
       write(23,rec=1) rivhgt_inf
       close(23)
 
-#ifdef UseCDF
+#ifdef UseCDF_CMF
       if( type=='cdf' )then
 
         !! == create netcdf and define dimensions
@@ -240,7 +240,7 @@ print *, 'calc_rivwth: width & depth calculation'
 
 
 
-#ifdef UseCDF
+#ifdef UseCDF_CMF
       CONTAINS
 !!================================================
       SUBROUTINE NCERROR(STATUS,STRING)

--- a/map/src/src_param/set_bifparam.F90
+++ b/map/src/src_param/set_bifparam.F90
@@ -5,7 +5,7 @@
 ! (if needed, number of bifurcation layers can be modified.)
 ! -- 10 layer exist in original. Reduced to 5 by s01-*sh script to reduce computation cost
 ! ================================================
-#ifdef UseCDF
+#ifdef UseCDF_CMF
 USE NETCDF
 #endif
       implicit none
@@ -196,7 +196,7 @@ print *, 'set_bifparam: read bifori.txt'
 
 
 
-#ifdef UseCDF
+#ifdef UseCDF_CMF
       CONTAINS
 !!================================================
       SUBROUTINE NCERROR(STATUS,STRING)


### PR DESCRIPTION
The adm/Mkinclude file has been updated in recent version to -DUseCDF_CMF instead of -DUseCDF, but corresponding update in map/src/src_param was not implemented. This pull request mainly fix this issue, and add the needed $(CFLAGS) back into map/src/src_param/Makefile.

For calc_outclm.F90, a line of CONTAINS needs to be moved outside of the ifdef block, in case -DUseCDF is activated. the CONTAINS line later then needs to be removed.

In testing, a few discharge points show very large values for unidentified reasons. For robustness and given the fact that discharge does not exceed 1.e10 m3/s in nature, an if block is added to redefine runoff exceeding 1.e10 to -9999.