### PR TITLE
Fix a bug in calc_levfrc.F90

### DIFF
--- a/etc/levee_params/src/calc_levfrc.F90
+++ b/etc/levee_params/src/calc_levfrc.F90
@@ -109,7 +109,7 @@
 ! set levee list resolution
       if( trim(listres)=='3sec' )then
         lsize=1./1200.
-      elseif( trim(listres)=='1min' )then
+      elseif( trim(listres)=='1sec' )then
         lsize=1./3600.
       else
         stop


### PR DESCRIPTION
The `'1min'` should be `'1sec'`.

Khanh